### PR TITLE
Specify platform as linux/x86_64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   screeps:
+    platform: linux/x86_64
     image: jomik/screeps-server:edge
     depends_on:
       - mongo


### PR DESCRIPTION
This is needed to run from an Apple Silicon machine, since that requires Docker to get help from QEMU.