### PR TITLE
Add in bash because `@screeps/driver` needs it now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM node:${NODE_VERSION}-alpine as screeps
 # They are so old that there is no changes to their package registry anyway..
 # hadolint ignore=DL3018
 RUN --mount=type=cache,target=/etc/apk/cache \
-  apk add --no-cache python2 make gcc g++
+  apk add --no-cache bash python2 make gcc g++
 
 # Install screeps
 WORKDIR /screeps


### PR DESCRIPTION
That was need to make `docker build` work, as a consequence to changes to `screeps` packaging.

Failing output from `docker build` before the change:
```
#9 87.72 > screeps@4.2.16 postinstall /screeps/node_modules/screeps
#9 87.72 > cd `node_modules` && npm explore @screeps/driver -- npx webpack
#9 87.72 
#9 88.22 npm ERR! code ENOENT
#9 88.22 npm ERR! syscall spawn bash
#9 88.22 npm ERR! file bash
#9 88.22 npm ERR! path bash
#9 88.22 npm ERR! errno ENOENT
#9 88.22 npm ERR! enoent spawn bash ENOENT
```