### PR TITLE
Auto update mods on startup

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,5 +6,7 @@ bots:
   simplebot: screepsbot-zeswarm
 
 launcherOptions:
+  # If set, automatically ensures all mods are updated
+  autoUpdate: false
   # If set, forward console messages to terminal
   logConsole: false

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "js-yaml": "4.1.0"
   },
   "scripts": {
-    "cli": "docker compose exec screeps cli"
+    "cli": "docker compose exec screeps cli",
+    "update": "docker compose exec screeps start --update"
   }
 }

--- a/screeps-start.js
+++ b/screeps-start.js
@@ -21,6 +21,8 @@ const loadPackage = (dir) =>
 const isDependency = (pkg, [name, version]) =>
   pkg.includes(name) || version.includes(pkg);
 
+const VERSION = /^(=|^|~|<|>|<=|>=)?\d+(?:\.\d+(?:\.\d+(?:.*)?)?)?$/
+
 const parseVersionSpec = (spec) => {
   const atIdx = spec.lastIndexOf("@");
   if (atIdx === -1) {
@@ -28,6 +30,9 @@ const parseVersionSpec = (spec) => {
   }
   const name = spec.substring(0, atIdx);
   const version = spec.substring(atIdx + 1);
+  if (!version.match(VERSION)) {
+    return [spec, "latest"];
+  }
   return [name, version];
 }
 

--- a/wiki/Updating.md
+++ b/wiki/Updating.md
@@ -9,6 +9,6 @@ Run `docker compose pull screeps` to download any new version of the image.
 You can run `docker compose pull` without the `screeps` specifier to pull all new images for the compose file.
 
 ### Update mods and bots
-Those that have specific versions set in `config.yml` can be updated by changing that.
-To update mods/bots that was installed without a version requirement (defaults to @latest at time of first startup) will have to be updated from within the container.
-See [Issue #23](https://github.com/Jomik/screeps-server/issues/23)
+Mods and bots can be updated by running `docker compose exec screeps start --update` and restarting the server. This will go over the
+installed packages and update any that are not pinned to their latest available version. You can pin a package
+to specific version in the config.yml, like so: `mod@1.2.3`.


### PR DESCRIPTION
This runs `npm outdated` as part of the mod installation and automatically installs newer versions of the mods.

Right now this will do it anytime there's an update. I debated making it work with a switch, but I'm not sure what sort of switch… I thought about using an envvar (say `UPDATE_MODS=1`, but I'm pretty sure that would require the container to be rebuilt, which doesn't exactly feel required. Possibly could be split into its own `bin/update` script and ran from outside the container, then a restart cycle?