### PR TITLE
Mount the home directory so we can keep the .screeps-history around

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - 21025:21025/tcp
     volumes:
       - ./config.yml:/screeps/config.yml
+      - screeps-user:/home/node
       - screeps-data:/data
       - screeps-mods:/screeps/mods
     environment:
@@ -32,5 +33,6 @@ services:
 volumes:
   screeps-data:
   screeps-mods:
+  screeps-user:
   redis-data:
   mongo-data:


### PR DESCRIPTION
This isn't exactly pretty, because there's more stuff in `$HOME` than just that file, but any attempt at just mounting that one file ends up with a lot of confusing, so this ends up being the safer solution. As a bonus, it also ends up preseving `.ash_history`, which is the shell's history (as well as some random `.npm` cache from mod installation).