### PR TITLE
Fix a crash if the modlist is fully empty

### DIFF
--- a/server/screeps-start.cjs
+++ b/server/screeps-start.cjs
@@ -208,7 +208,7 @@ const writeModsConfiguration = () => {
   console.log("Writing mods configuration");
   const mods = config.mods || [];
   const bots = config.bots || {};
-  const { dependencies } = loadPackage(ModsDir);
+  const { dependencies = {} } = loadPackage(ModsDir);
   /** @type {Pick<Config, "mods" | "bots">} */
   const modsJSON = { mods: [], bots: {} };
 


### PR DESCRIPTION
Just something I stumbled on while investigating something else.