### PR TITLE
fix: make launcherOptions config optional

### DIFF
--- a/server/screeps-start.cjs
+++ b/server/screeps-start.cjs
@@ -13,7 +13,23 @@ const ConfigPath = path.join(RootDir, "config.yml");
 
 process.chdir(RootDir);
 
-const config = /** @type {Config} */ (yaml.load(fs.readFileSync(ConfigPath, "utf8")));
+const rawConfig = /** @type {Config} */ (yaml.load(fs.readFileSync(ConfigPath, "utf8"))) || {};
+
+const steamKey = process.env.STEAM_KEY || rawConfig.steamKey;
+if (!steamKey) {
+  throw new Error("Missing steam API key. Set the STEAM_KEY environment variable or steamKey in config.yml.");
+}
+
+/** @type {ResolvedConfig} */
+const config = {
+  steamKey,
+  mods: rawConfig.mods || [],
+  bots: rawConfig.bots || {},
+  launcherOptions: {
+    autoUpdate: false,
+    ...rawConfig.launcherOptions,
+  },
+};
 
 /**
  * @param {string} dir
@@ -53,8 +69,8 @@ const parseVersionSpec = (spec) => {
 
 const installPackages = () => {
   console.log("Updating dependencies");
-  const mods = config.mods || [];
-  const bots = config.bots || {};
+  const mods = config.mods;
+  const bots = config.bots;
 
   const modsPackage = loadPackage(ModsDir);
   const dependencies = modsPackage.dependencies || {};
@@ -122,8 +138,8 @@ const installPackages = () => {
  * @returns 
  */
 const updatePackages = (doUpdate) => {
-  const mods = config.mods || [];
-  const bots = config.bots || {};
+  const mods = config.mods;
+  const bots = config.bots;
 
   const modsPackage = loadPackage(ModsDir);
   const dependencies = modsPackage.dependencies || {};
@@ -193,10 +209,10 @@ const updatePackages = (doUpdate) => {
 
 const writeModsConfiguration = () => {
   console.log("Writing mods configuration");
-  const mods = config.mods || [];
-  const bots = config.bots || {};
+  const mods = config.mods;
+  const bots = config.bots;
   const { dependencies = {} } = loadPackage(ModsDir);
-  /** @type {Pick<Config, "mods" | "bots">} */
+  /** @type {Pick<ResolvedConfig, "mods" | "bots">} */
   const modsJSON = { mods: [], bots: {} };
 
   for (const [name, version] of Object.entries(dependencies)) {
@@ -255,7 +271,7 @@ const start = async () => {
   writeModsConfiguration();
 
   const updateOpt = process.argv.includes("--update");
-  const updateNeeded = updatePackages(updateOpt || config.launcherOptions?.autoUpdate);
+  const updateNeeded = updatePackages(updateOpt || config.launcherOptions.autoUpdate);
 
   if (updateOpt) {
     process.exit(updateNeeded ? 1 : 0);
@@ -267,14 +283,14 @@ const start = async () => {
 
   /** @type {Record<string, any>} */
   const options = {
-    steam_api_key: process.env.STEAM_KEY || config.steamKey,
+    steam_api_key: config.steamKey,
     storage_disable: false,
     processors_cnt: cores,
     runners_cnt: 1,
     runner_threads: Math.max(cores - 1, 1),
   };
 
-  const launcherOptions = config.launcherOptions || {};
+  const launcherOptions = config.launcherOptions;
 
   for (const [configKey, optionsKey] of Object.entries(LauncherConfigMap)) {
     if (configKey in launcherOptions) {

--- a/server/screeps-start.cjs
+++ b/server/screeps-start.cjs
@@ -255,7 +255,7 @@ const start = async () => {
   writeModsConfiguration();
 
   const updateOpt = process.argv.includes("--update");
-  const updateNeeded = updatePackages(updateOpt || config.launcherOptions.autoUpdate);
+  const updateNeeded = updatePackages(updateOpt || config.launcherOptions?.autoUpdate);
 
   if (updateOpt) {
     process.exit(updateNeeded ? 1 : 0);

--- a/server/types.d.ts
+++ b/server/types.d.ts
@@ -1,17 +1,17 @@
 
 interface LauncherOptions {
-    autoUpdate: boolean;
-    logConsole: boolean;
-    runnerThreads: number;
-    processorCount: number;
-    storageTimeout: number;
-    logRotateKeep: number;
-    restartInterval: number;
+    autoUpdate?: boolean;
+    logConsole?: boolean;
+    runnerThreads?: number;
+    processorCount?: number;
+    storageTimeout?: number;
+    logRotateKeep?: number;
+    restartInterval?: number;
 }
 
 interface Config {
     steamKey: string;
     mods: string[];
     bots: Record<string, string>;
-    launcherOptions: LauncherOptions;
+    launcherOptions?: LauncherOptions;
 }

--- a/server/types.d.ts
+++ b/server/types.d.ts
@@ -16,9 +16,4 @@ interface Config {
     launcherOptions?: LauncherOptions;
 }
 
-interface ResolvedConfig {
-    steamKey: string;
-    mods: string[];
-    bots: Record<string, string>;
-    launcherOptions: LauncherOptions;
-}
+type ResolvedConfig = Required<Config>;

--- a/server/types.d.ts
+++ b/server/types.d.ts
@@ -10,8 +10,15 @@ interface LauncherOptions {
 }
 
 interface Config {
+    steamKey?: string;
+    mods?: string[];
+    bots?: Record<string, string>;
+    launcherOptions?: LauncherOptions;
+}
+
+interface ResolvedConfig {
     steamKey: string;
     mods: string[];
     bots: Record<string, string>;
-    launcherOptions?: LauncherOptions;
+    launcherOptions: LauncherOptions;
 }


### PR DESCRIPTION
## Summary

Prevents a startup crash loop when `launcherOptions` is absent from the config YAML. Rather than patching the single crash site, this centralizes all config defaults at load time — the raw YAML is merged with explicit defaults immediately after parsing, producing a `ResolvedConfig` where all fields are guaranteed present.

This eliminates 8 scattered ad-hoc fallbacks (`|| []`, `|| {}`, `?.`) throughout the codebase and makes the default values discoverable in one place.

## Decisions & callouts

- Introduced a `ResolvedConfig` type separate from `Config` — `Config` represents the YAML input shape (all optional), `ResolvedConfig` is the runtime shape (all required). This keeps the types honest about what the YAML can actually contain.
- `autoUpdate` is the only `LauncherOptions` field that gets an explicit default (`false`), since the others are only accessed via a dynamic `if (configKey in launcherOptions)` check that already handles missing fields.
- Added `|| {}` guard on `yaml.load()` to handle an entirely empty YAML file (which returns `undefined`).
- `steamKey` is resolved early from `STEAM_KEY` env var or `config.steamKey`, with a fast-fail error if neither is set. The duplicate resolution at the launcher usage site is removed.

## Manual testing

- [ ] Remove `launcherOptions` entirely from `config.yml` and start the server — should boot without crashing
- [ ] Add only a partial `launcherOptions` (e.g. just `logConsole: true`) — should apply that option and use defaults for the rest
- [ ] Remove all content from `config.yml` (empty file) — should fail with a clear "Missing steam API key" error
- [ ] Unset `STEAM_KEY` env var and remove `steamKey` from config — should fail with a clear error at startup