### PR TITLE
Do a reading pass over the wiki info

### DIFF
--- a/wiki/Getting-started.md
+++ b/wiki/Getting-started.md
@@ -1,12 +1,13 @@
-### Prerequisites
+# Quickstart Guide
 
 A working [Docker](https://www.docker.com/) installation.
 You can use [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
-### Setup
+## Setup
 
-Download the [compose file](./docker-compose.yml), [envfile](./.env.sample) and [configuration](./config.yml) file to your computer. You can put this in your Screeps project.
+Download the [compose file](../docker-compose.yml), [envfile](../.env.sample), [configuration file](../config.yml) to your computer. You can put this in your Screeps project.
 Copy `.env.sample` to `.env`, this can hold secrets for you, and should be ignored in git!
+You can also get the [package.json file](../package.json) because it has scripts set up for quick server administration. You'll need `npm` available for that, and this is only because of the `scripts` section in it, so running `npm install` is entirely unnecessary.
 
 You can use this command (in a shell) to do the above, in your current directory.
 
@@ -14,15 +15,30 @@ You can use this command (in a shell) to do the above, in your current directory
 curl --remote-name-all https://raw.githubusercontent.com/Jomik/screeps-server/main/{docker-compose.yml,.env.sample,config.yml} && cp .env.sample .env && echo ".env" >> .gitignore
 ```
 
-Paste the the value labeled `Key` from your [Steam API key](https://steamcommunity.com/dev/apikey) into `.env`.
-### Starting the server
+That snippet does not download `package.json`; grab the administration scripts and merge them in your own package.json if you want to use them.
 
-In your project run `docker compose up -d`.
-Run `docker compose logs screeps -f` to view and follow the logs for the screeps-server container.
+Paste the value labeled `Key` from your [Steam API key](https://steamcommunity.com/dev/apikey) into `.env`.
+
+## Starting the server
+
+In your project run `npm run start`/`docker compose up -d`.
+Run `npm run start:logs`/`docker compose logs screeps -f` to view and follow the logs for the screeps-server container.
 To stop following the logs, press `CTRL + C`.
 Assuming nothing went wrong, you should be able to connect to your server on `http://localhost:21025`.
 
-### Stopping the server
-In your project run `docker compose stop`. This will stop the containers, but not remove them, so starting is quicker again.
+## Stopping the server
 
-To __fully__ wipe the server and its data, run `docker compose down -v`. This removes containers, networks and volumes.
+In your project run `npm run stop`/`docker compose stop`. This will stop the containers, but not remove them, so starting is quicker again.
+
+If you want to manually recreate containers, you can do so with `npm run reset`/`docker compose down`. This keeps the volumes so the server data will be kept and restarting the server will recreate the containers.
+
+To __fully__ wipe the server and its data, run `npm run reset:hard`/`docker compose down -v`. This removes containers, networks and volumes.
+
+## Checking the logs
+
+Once the server is running, you can inspect what it's doing with `npm run logs`/`docker compose logs -ft -n 100 screeps`. Generally you also want `logConfig: true` in config.yml so the screeps server redirects its output into the standard output, which is what Docker collects into its logs.
+
+## Connecting to the server's CLI
+With the server running, you can `npm run cli`/`docker compose exec screeps cli` to connect to the server's administration console. See the [Screepspl.us wiki](https://wiki.screepspl.us/Private_Server_Common_Tasks/) for more information.
+
+One-off commands can be run through the `cli` script's `-c` parameter, so `npm run cli -- -c 'system.pauseSimulation();'`/`docker compose exec screeps cli -c 'system.pauseSimulation()'` will pause the server.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,8 +1,10 @@
 ### Help, my server is running but I can't connect.
   - Follow the instructions for [screepsmod-auth](https://github.com/ScreepsMods/screepsmod-auth)
+
 ### I can't push any code via `rollup` to my server.
   - Make sure your `screeps.json` configuration in your project is set properly.
   - In your `email:` field, simply put in your `username`. Verify your password is the same as your `screepsmod-auth` setting.
+
 ### My map is all red, I can't actually spawn in!
 
   - This is most likely a result of your map not loaded properly on first-run. To fix it do the following.

--- a/wiki/Updating.md
+++ b/wiki/Updating.md
@@ -9,6 +9,6 @@ Run `docker compose pull screeps` to download any new version of the image.
 You can run `docker compose pull` without the `screeps` specifier to pull all new images for the compose file.
 
 ### Update mods and bots
-Mods and bots can be updated by running `docker compose exec screeps start --update` and restarting the server. This will go over the
-installed packages and update any that are not pinned to their latest available version. You can pin a package
-to specific version in the config.yml, like so: `mod@1.2.3`.
+Mods and bots can be updated by running `npm run update`/`docker compose exec screeps start --update` and restarting the server.
+This will go over the installed packages and update any that are not pinned to their latest available version.
+You can pin a package to specific version in the config.yml, like so: `mod@1.2.3`.


### PR DESCRIPTION
This adds info about the admin scripts from package.json and document both styles (npm vs direct docker) all over the wiki. Also adds some information about wiping containers / the entire stack.