### PR TITLE
Fix a bug with `-c` in the cli script

### DIFF
--- a/server/screeps-cli.cjs
+++ b/server/screeps-cli.cjs
@@ -34,10 +34,11 @@ function cli(host, port, cmd = undefined) {
   /** @type {repl.REPLServer} */
   let rl;
   let connected = false;
+  let commandAnswered = false;
 
   /**
    * Send a command to the server for execution
-   * @param {string} input 
+   * @param {string} input
    */
   const executeCommand = (input) => {
     // The server side feeds the socket through `readline`, which splits on
@@ -108,8 +109,9 @@ function cli(host, port, cmd = undefined) {
           return;
         }
 
+        commandAnswered = true;
         process.stdout.write(cleaned);
-        process.exit(1);
+        process.exit(0);
       });
       executeCommand(cmd);
       return;
@@ -172,6 +174,10 @@ function cli(host, port, cmd = undefined) {
   socket.on('close', () => {
     if (rl) {
       rl.close();
+    }
+    if (cmd) {
+      process.exit(!commandAnswered ? 1 : 0);
+      return;
     }
     process.exit(0);
   });


### PR DESCRIPTION
It would return a non-zero status even in case of success (not that we can really tell), and also sometimes shadow its own output because of the two 'data' listeners.