### PR TITLE
fix(ci): use github.repository expression in deploy matrix

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -2,7 +2,6 @@ name: Deploy Images to GHCR
 
 env:
   REGISTRY: ghcr.io
-  IMAGE: ${{github.repository}}
 
 on:
   push:
@@ -21,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         imageName:
-          - ${IMAGE}
+          - ${{ github.repository }}
         node: [22, 24]
         platform:
           - pair: linux/amd64
@@ -91,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         imageName:
-          - ${IMAGE}
+          - ${{ github.repository }}
         node: [22, 24]
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

The deploy-image workflow matrix used `${IMAGE}` (a literal shell string) as the `imageName` value. GitHub Actions does not expand `env` variables in `strategy.matrix` context, so the pipeline was receiving the literal string `${IMAGE}` as the image name instead of the actual repository path.

Replaced with `${{ github.repository }}` which is evaluated at workflow parse time, and removed the now-unused `IMAGE` env var.

## References

- Broken commit: https://github.com/Jomik/screeps-server/commit/147dbbfb8e83fa9090417953c24df94040cf80ab